### PR TITLE
Update homepage and about copy to reflect ForgentAI founding engineer role

### DIFF
--- a/src/routes/about.svelte
+++ b/src/routes/about.svelte
@@ -28,7 +28,7 @@
 				</p>
 				<p>
 					In my career I have worked on building solutions for various domains, such as ERP, retail solution, etc.
-					Right now I'm working on large scale logs processing.
+					Right now I work as a founding engineer at ForgentAI, where we build AI solutions for public procurements.
 				</p>
 
 				<p>I've graduated from East West University in Computer Science & Engineering.</p>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -26,7 +26,8 @@
 				>
 			</h1>
 			<h2 class="text-gray-600 dark:text-gray-200 text-center mb-2">
-				I'm a <span class="font-bold">Software Engineer,</span> currently working on large scale logs processing @aws
+				I'm a <span class="font-bold">Founding Engineer,</span> building AI solutions for public
+				procurements at ForgentAI
 			</h2>
 
 			<div class="mb-4 mt-8">


### PR DESCRIPTION
### Motivation
- Update the public-facing copy to reflect the current role and focus as a Founding Engineer at ForgentAI working on AI solutions for public procurements.

### Description
- Changed the homepage intro in `src/routes/index.svelte` and the career paragraph in `src/routes/about.svelte` to mention the Founding Engineer role at ForgentAI and the focus on AI for public procurements.

### Testing
- Ran `npm run check`; `svelte-check` completed with 0 errors and 13 warnings (warnings relate to `SourceMapConsumer`/`lib/mappings.wasm`) and no new errors introduced by these edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1755b64d34832197442a0c0aea3a7a)