### PR TITLE
Fix GitHub Pages workflow: update actions, enable token write permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,26 +6,22 @@ on:
             - main
     pull_request:
 
+permissions:
+    contents: write
+
 jobs:
     deploy:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         concurrency:
             group: ${{ github.workflow }}-${{ github.ref }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v4
               with:
                   node-version: '14'
-
-            - name: Cache dependencies
-              uses: actions/cache@v2
-              with:
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-node-
+                  cache: npm
 
             - run: npm ci
             - run: npm run build


### PR DESCRIPTION
### Motivation
- The Pages deployment was blocked by outdated action versions and a deprecated cache step which can fail after cache service changes. 
- The workflow also lacked the permission required for the `GITHUB_TOKEN` to push the generated site, preventing `peaceiris/actions-gh-pages` from publishing.

### Description
- Update the workflow to use `actions/checkout@v4` and `actions/setup-node@v4` and change the runner to `ubuntu-22.04`.
- Remove the separate `actions/cache@v2` step and enable npm caching via `setup-node` with `cache: npm`.
- Add `permissions: contents: write` so the `GITHUB_TOKEN` can push the built site to Pages while keeping `peaceiris/actions-gh-pages@v3` as the deploy step.
- Preserve `node-version: '14'` to avoid introducing immediate dependency resolution changes for the repo.

### Testing
- Ran `git diff --check` which showed the workflow diff and no whitespace errors.
- Attempted `npm ci` and `npm run build` locally but `npm ci` failed with peer dependency resolution errors (`ERESOLVE`) due to Svelte/SvelteKit version mismatches. 
- Attempted `npm ci --legacy-peer-deps` and package operations but they encountered npm registry `403 Forbidden` errors preventing a full local build. 
- Recommend running the updated workflow on GitHub Actions (push the branch) for an end-to-end validation since local build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b555140c483219e4c85a03c1e2e7b)