### PR TITLE
Update GitHub Pages workflow, migrate actions/runners and refresh lockfile (pin Svelte v3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,26 +6,22 @@ on:
             - main
     pull_request:
 
+permissions:
+    contents: write
+
 jobs:
     deploy:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         concurrency:
             group: ${{ github.workflow }}-${{ github.ref }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Setup Node
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v4
               with:
                   node-version: '14'
-
-            - name: Cache dependencies
-              uses: actions/cache@v2
-              with:
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-node-
+                  cache: npm
 
             - run: npm ci
             - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-static": "^1.0.0-next.18",
-				"@sveltejs/kit": "*",
+				"@sveltejs/kit": "next",
 				"@types/cookie": "^0.4.0",
 				"@typescript-eslint/eslint-plugin": "^5.5.0",
 				"@typescript-eslint/parser": "^5.5.0",
@@ -32,24 +32,12 @@
 				"prettier": "^2.5.1",
 				"prettier-plugin-svelte": "^2.4.0",
 				"sass": "^1.39.0",
-				"svelte": "^4.2.19",
+				"svelte": "^3.42.4",
 				"svelte-check": "^2.2.5",
 				"svelte-preprocess": "^4.9.0",
 				"tailwindcss": "^2.2.9",
 				"tslib": "^2.3.1",
 				"typescript": "^4.4.2"
-			}
-		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -242,49 +230,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-			"dependencies": {
-				"@jridgewell/set-array": "^1.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
-		},
-		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-			"dependencies": {
-				"@jridgewell/resolve-uri": "^3.1.0",
-				"@jridgewell/sourcemap-codec": "^1.4.14"
-			}
-		},
 		"node_modules/@lukeed/csprng": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.0.1.tgz",
@@ -339,6 +284,19 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@rollup/pluginutils": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+			"integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
+			"dev": true,
+			"dependencies": {
+				"estree-walker": "^2.0.1",
+				"picomatch": "^2.2.2"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
 		"node_modules/@sveltejs/adapter-static": {
 			"version": "1.0.0-next.21",
 			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.21.tgz",
@@ -366,51 +324,31 @@
 				"svelte": "^3.44.0"
 			}
 		},
-		"node_modules/@sveltejs/kit/node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.4.0.tgz",
-			"integrity": "sha512-6QupI/jemMfK+yI2pMtJcu5iO2gtgTfcBdGwMZZt+lgbFELhszbDl6Qjh000HgAV8+XUA+8EY8DusOFk8WhOIg==",
+		"node_modules/@sveltejs/vite-plugin-svelte": {
+			"version": "1.0.0-next.31",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.31.tgz",
+			"integrity": "sha512-8K3DcGP1V+XBv389u32S6wt8xiun6hHd5wn28AKLSoNTIhOmJOA2RJUJzp0seTRI86Shme4lzHI2Fgq4qz1wXQ==",
 			"dev": true,
 			"dependencies": {
-				"debug": "^4.3.4",
-				"deepmerge": "^4.2.2",
-				"kleur": "^4.1.5",
-				"magic-string": "^0.26.7",
-				"svelte-hmr": "^0.15.1",
-				"vitefu": "^0.2.2"
+				"@rollup/pluginutils": "^4.1.1",
+				"debug": "^4.3.3",
+				"kleur": "^4.1.4",
+				"magic-string": "^0.25.7",
+				"require-relative": "^0.8.7",
+				"svelte-hmr": "^0.14.7"
 			},
 			"engines": {
-				"node": "^14.18.0 || >= 16"
+				"node": "^14.13.1 || >= 16"
 			},
 			"peerDependencies": {
+				"diff-match-patch": "^1.0.5",
 				"svelte": "^3.44.0",
-				"vite": "^3.0.0"
-			}
-		},
-		"node_modules/@sveltejs/kit/node_modules/@sveltejs/vite-plugin-svelte/node_modules/vitefu": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
-			"integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
-			"dev": true,
-			"peerDependencies": {
-				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
+				"vite": "^2.6.0"
 			},
 			"peerDependenciesMeta": {
-				"vite": {
+				"diff-match-patch": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@sveltejs/kit/node_modules/magic-string": {
-			"version": "0.26.7",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
-			"integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
-			"dev": true,
-			"dependencies": {
-				"sourcemap-codec": "^1.4.8"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@trysound/sax": {
@@ -428,15 +366,16 @@
 			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
 			"dev": true
 		},
-		"node_modules/@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
 			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "16.11.11",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
+			"integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==",
 			"dev": true
 		},
 		"node_modules/@types/parse-json": {
@@ -446,19 +385,18 @@
 			"dev": true
 		},
 		"node_modules/@types/pug": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
-			"integrity": "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.5.tgz",
+			"integrity": "sha512-LOnASQoeNZMkzexRuyqcBBDZ6rS+rQxUMkmj5A0PkhhiSZivLIuz6Hxyr1mkGoEZEkk66faROmpMi4fFkrKsBA==",
 			"dev": true
 		},
 		"node_modules/@types/sass": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
-			"integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
-			"deprecated": "This is a stub types definition. sass provides its own type definitions, so you do not need this installed.",
+			"version": "1.43.1",
+			"resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
+			"integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
 			"dev": true,
 			"dependencies": {
-				"sass": "*"
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -748,14 +686,6 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
-		"node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
-		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -790,14 +720,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.1.0"
-			}
-		},
-		"node_modules/axobject-query": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
-			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -869,7 +791,7 @@
 		"node_modules/buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
 			"dev": true,
 			"engines": {
 				"node": "*"
@@ -968,29 +890,6 @@
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/code-red": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
-			"integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.15",
-				"@types/estree": "^1.0.1",
-				"acorn": "^8.10.0",
-				"estree-walker": "^3.0.3",
-				"periscopic": "^3.1.0"
-			}
-		},
-		"node_modules/code-red/node_modules/acorn": {
-			"version": "8.12.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/color": {
@@ -1290,9 +1189,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
@@ -1312,28 +1211,11 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
-		"node_modules/deepmerge": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/defined": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
 			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
 			"dev": true
-		},
-		"node_modules/dequal": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/detect-indent": {
 			"version": "6.1.0",
@@ -1491,7 +1373,7 @@
 		"node_modules/es6-promise": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-			"integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
+			"integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
 			"dev": true
 		},
 		"node_modules/esbuild": {
@@ -2024,12 +1906,10 @@
 			}
 		},
 		"node_modules/estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dependencies": {
-				"@types/estree": "^1.0.0"
-			}
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true
 		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
@@ -2478,14 +2358,6 @@
 				"node": ">=0.12.0"
 			}
 		},
-		"node_modules/is-reference": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
-			"integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
-			"dependencies": {
-				"@types/estree": "*"
-			}
-		},
 		"node_modules/is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
@@ -2547,9 +2419,9 @@
 			}
 		},
 		"node_modules/kleur": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -2582,11 +2454,6 @@
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
-		},
-		"node_modules/locate-character": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
 		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
@@ -2631,11 +2498,12 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.11",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
-			"integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+			"version": "0.25.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+			"dev": true,
 			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.0"
+				"sourcemap-codec": "^1.4.4"
 			}
 		},
 		"node_modules/mdn-data": {
@@ -2688,21 +2556,18 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
 		},
 		"node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"dependencies": {
-				"minimist": "^1.2.6"
+				"minimist": "^1.2.5"
 			},
 			"bin": {
 				"mkdirp": "bin/cmd.js"
@@ -2906,16 +2771,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/periscopic": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
-			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-			"dependencies": {
-				"@types/estree": "^1.0.0",
-				"estree-walker": "^3.0.0",
-				"is-reference": "^3.0.0"
 			}
 		},
 		"node_modules/picocolors": {
@@ -3601,6 +3456,12 @@
 				"url": "https://github.com/sponsors/mysticatea"
 			}
 		},
+		"node_modules/require-relative": {
+			"version": "0.8.7",
+			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+			"dev": true
+		},
 		"node_modules/resolve": {
 			"version": "1.20.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -3713,7 +3574,7 @@
 		"node_modules/sander": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
-			"integrity": "sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==",
+			"integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
 			"dev": true,
 			"dependencies": {
 				"es6-promise": "^3.1.2",
@@ -3726,7 +3587,6 @@
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
 			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
 			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.3"
@@ -3814,7 +3674,7 @@
 		"node_modules/sorcery": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
-			"integrity": "sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==",
+			"integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
 			"dev": true,
 			"dependencies": {
 				"buffer-crc32": "^0.2.5",
@@ -3839,6 +3699,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
 			"integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3847,7 +3708,6 @@
 			"version": "1.4.8",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
 			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-			"deprecated": "Please use @jridgewell/sourcemap-codec instead",
 			"dev": true
 		},
 		"node_modules/stable": {
@@ -3921,27 +3781,11 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "4.2.19",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.19.tgz",
-			"integrity": "sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==",
-			"dependencies": {
-				"@ampproject/remapping": "^2.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.15",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"@types/estree": "^1.0.1",
-				"acorn": "^8.9.0",
-				"aria-query": "^5.3.0",
-				"axobject-query": "^4.0.0",
-				"code-red": "^1.0.3",
-				"css-tree": "^2.3.1",
-				"estree-walker": "^3.0.3",
-				"is-reference": "^3.0.1",
-				"locate-character": "^3.0.0",
-				"magic-string": "^0.30.4",
-				"periscopic": "^3.1.0"
-			},
+			"version": "3.44.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.2.tgz",
+			"integrity": "sha512-jrZhZtmH3ZMweXg1Q15onb8QlWD+a5T5Oca4C1jYvSURp2oD35h4A5TV6t6MEa93K4LlX6BkafZPdQoFjw/ylA==",
 			"engines": {
-				"node": ">=16"
+				"node": ">= 8"
 			}
 		},
 		"node_modules/svelte-awesome": {
@@ -3976,21 +3820,18 @@
 			}
 		},
 		"node_modules/svelte-hmr": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.3.tgz",
-			"integrity": "sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==",
+			"version": "0.14.7",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.7.tgz",
+			"integrity": "sha512-pDrzgcWSoMaK6AJkBWkmgIsecW0GChxYZSZieIYfCP0v2oPyx2CYU/zm7TBIcjLVUPP714WxmViE9Thht4etog==",
 			"dev": true,
-			"engines": {
-				"node": "^12.20 || ^14.13.1 || >= 16"
-			},
 			"peerDependencies": {
-				"svelte": "^3.19.0 || ^4.0.0"
+				"svelte": ">=3.19.0"
 			}
 		},
 		"node_modules/svelte-preprocess": {
-			"version": "4.10.7",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
-			"integrity": "sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==",
+			"version": "4.9.8",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.9.8.tgz",
+			"integrity": "sha512-EQS/oRZzMtYdAprppZxY3HcysKh11w54MgA63ybtL+TAZ4hVqYOnhw41JVJjWN9dhPnNjjLzvbZ2tMhTsla1Og==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -4007,12 +3848,12 @@
 			"peerDependencies": {
 				"@babel/core": "^7.10.2",
 				"coffeescript": "^2.5.1",
-				"less": "^3.11.3 || ^4.0.0",
+				"less": "^3.11.3",
 				"postcss": "^7 || ^8",
-				"postcss-load-config": "^2.1.0 || ^3.0.0 || ^4.0.0",
+				"postcss-load-config": "^2.1.0 || ^3.0.0",
 				"pug": "^3.0.0",
 				"sass": "^1.26.8",
-				"stylus": "^0.55.0",
+				"stylus": "^0.54.7",
 				"sugarss": "^2.0.0",
 				"svelte": "^3.23.0",
 				"typescript": "^3.9.5 || ^4.0.0"
@@ -4052,43 +3893,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/svelte-preprocess/node_modules/magic-string": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-			"dev": true,
-			"dependencies": {
-				"sourcemap-codec": "^1.4.8"
-			}
-		},
-		"node_modules/svelte/node_modules/acorn": {
-			"version": "8.12.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-			"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/svelte/node_modules/css-tree": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-			"dependencies": {
-				"mdn-data": "2.0.30",
-				"source-map-js": "^1.0.1"
-			},
-			"engines": {
-				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-			}
-		},
-		"node_modules/svelte/node_modules/mdn-data": {
-			"version": "2.0.30",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
 		},
 		"node_modules/svgo": {
 			"version": "2.8.0",
@@ -4397,15 +4201,6 @@
 		}
 	},
 	"dependencies": {
-		"@ampproject/remapping": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"requires": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			}
-		},
 		"@babel/code-frame": {
 			"version": "7.12.11",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -4558,40 +4353,6 @@
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
 		},
-		"@jridgewell/gen-mapping": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-			"requires": {
-				"@jridgewell/set-array": "^1.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			}
-		},
-		"@jridgewell/resolve-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
-		},
-		"@jridgewell/set-array": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="
-		},
-		"@jridgewell/sourcemap-codec": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
-		},
-		"@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-			"requires": {
-				"@jridgewell/resolve-uri": "^3.1.0",
-				"@jridgewell/sourcemap-codec": "^1.4.14"
-			}
-		},
 		"@lukeed/csprng": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.0.1.tgz",
@@ -4631,6 +4392,16 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@rollup/pluginutils": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.1.tgz",
+			"integrity": "sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==",
+			"dev": true,
+			"requires": {
+				"estree-walker": "^2.0.1",
+				"picomatch": "^2.2.2"
+			}
+		},
 		"@sveltejs/adapter-static": {
 			"version": "1.0.0-next.21",
 			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.21.tgz",
@@ -4647,40 +4418,20 @@
 				"cheap-watch": "^1.0.4",
 				"sade": "^1.7.4",
 				"vite": "^2.6.12"
-			},
-			"dependencies": {
-				"@sveltejs/vite-plugin-svelte": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.4.0.tgz",
-					"integrity": "sha512-6QupI/jemMfK+yI2pMtJcu5iO2gtgTfcBdGwMZZt+lgbFELhszbDl6Qjh000HgAV8+XUA+8EY8DusOFk8WhOIg==",
-					"dev": true,
-					"requires": {
-						"debug": "^4.3.4",
-						"deepmerge": "^4.2.2",
-						"kleur": "^4.1.5",
-						"magic-string": "^0.26.7",
-						"svelte-hmr": "^0.15.1",
-						"vitefu": "^0.2.2"
-					},
-					"dependencies": {
-						"vitefu": {
-							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
-							"integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
-							"dev": true,
-							"requires": {}
-						}
-					}
-				},
-				"magic-string": {
-					"version": "0.26.7",
-					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
-					"integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
-					"dev": true,
-					"requires": {
-						"sourcemap-codec": "^1.4.8"
-					}
-				}
+			}
+		},
+		"@sveltejs/vite-plugin-svelte": {
+			"version": "1.0.0-next.31",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.31.tgz",
+			"integrity": "sha512-8K3DcGP1V+XBv389u32S6wt8xiun6hHd5wn28AKLSoNTIhOmJOA2RJUJzp0seTRI86Shme4lzHI2Fgq4qz1wXQ==",
+			"dev": true,
+			"requires": {
+				"@rollup/pluginutils": "^4.1.1",
+				"debug": "^4.3.3",
+				"kleur": "^4.1.4",
+				"magic-string": "^0.25.7",
+				"require-relative": "^0.8.7",
+				"svelte-hmr": "^0.14.7"
 			}
 		},
 		"@trysound/sax": {
@@ -4695,15 +4446,16 @@
 			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
 			"dev": true
 		},
-		"@types/estree": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
-		},
 		"@types/json-schema": {
 			"version": "7.0.9",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
 			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "16.11.11",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
+			"integrity": "sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==",
 			"dev": true
 		},
 		"@types/parse-json": {
@@ -4713,18 +4465,18 @@
 			"dev": true
 		},
 		"@types/pug": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
-			"integrity": "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.5.tgz",
+			"integrity": "sha512-LOnASQoeNZMkzexRuyqcBBDZ6rS+rQxUMkmj5A0PkhhiSZivLIuz6Hxyr1mkGoEZEkk66faROmpMi4fFkrKsBA==",
 			"dev": true
 		},
 		"@types/sass": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
-			"integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
+			"version": "1.43.1",
+			"resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
+			"integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
 			"dev": true,
 			"requires": {
-				"sass": "*"
+				"@types/node": "*"
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
@@ -4909,14 +4661,6 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
-		"aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"requires": {
-				"dequal": "^2.0.3"
-			}
-		},
 		"array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -4936,11 +4680,6 @@
 				"picocolors": "^1.0.0",
 				"postcss-value-parser": "^4.1.0"
 			}
-		},
-		"axobject-query": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
-			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.2",
@@ -4995,7 +4734,7 @@
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
 			"dev": true
 		},
 		"bytes": {
@@ -5064,25 +4803,6 @@
 				"is-glob": "~4.0.1",
 				"normalize-path": "~3.0.0",
 				"readdirp": "~3.6.0"
-			}
-		},
-		"code-red": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
-			"integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
-			"requires": {
-				"@jridgewell/sourcemap-codec": "^1.4.15",
-				"@types/estree": "^1.0.1",
-				"acorn": "^8.10.0",
-				"estree-walker": "^3.0.3",
-				"periscopic": "^3.1.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "8.12.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-					"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg=="
-				}
 			}
 		},
 		"color": {
@@ -5306,9 +5026,9 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-			"integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
@@ -5320,22 +5040,11 @@
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
-		"deepmerge": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-			"dev": true
-		},
 		"defined": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
 			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
 			"dev": true
-		},
-		"dequal": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
 		},
 		"detect-indent": {
 			"version": "6.1.0",
@@ -5454,7 +5163,7 @@
 		"es6-promise": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-			"integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
+			"integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
 			"dev": true
 		},
 		"esbuild": {
@@ -5803,12 +5512,10 @@
 			"dev": true
 		},
 		"estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"requires": {
-				"@types/estree": "^1.0.0"
-			}
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.3",
@@ -6158,14 +5865,6 @@
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
 		},
-		"is-reference": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
-			"integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
-			"requires": {
-				"@types/estree": "*"
-			}
-		},
 		"is-resolvable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
@@ -6222,9 +5921,9 @@
 			}
 		},
 		"kleur": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
 			"dev": true
 		},
 		"levn": {
@@ -6248,11 +5947,6 @@
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
-		},
-		"locate-character": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
 		},
 		"lodash": {
 			"version": "4.17.21",
@@ -6294,11 +5988,12 @@
 			}
 		},
 		"magic-string": {
-			"version": "0.30.11",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
-			"integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+			"version": "0.25.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+			"dev": true,
 			"requires": {
-				"@jridgewell/sourcemap-codec": "^1.5.0"
+				"sourcemap-codec": "^1.4.4"
 			}
 		},
 		"mdn-data": {
@@ -6339,18 +6034,18 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
 		},
 		"mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "^1.2.6"
+				"minimist": "^1.2.5"
 			}
 		},
 		"modern-normalize": {
@@ -6498,16 +6193,6 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"dev": true
-		},
-		"periscopic": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
-			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-			"requires": {
-				"@types/estree": "^1.0.0",
-				"estree-walker": "^3.0.0",
-				"is-reference": "^3.0.0"
-			}
 		},
 		"picocolors": {
 			"version": "1.0.0",
@@ -6938,6 +6623,12 @@
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true
 		},
+		"require-relative": {
+			"version": "0.8.7",
+			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+			"dev": true
+		},
 		"resolve": {
 			"version": "1.20.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
@@ -7011,7 +6702,7 @@
 		"sander": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
-			"integrity": "sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==",
+			"integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
 			"dev": true,
 			"requires": {
 				"es6-promise": "^3.1.2",
@@ -7091,7 +6782,7 @@
 		"sorcery": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
-			"integrity": "sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==",
+			"integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
 			"dev": true,
 			"requires": {
 				"buffer-crc32": "^0.2.5",
@@ -7109,7 +6800,8 @@
 		"source-map-js": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
-			"integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA=="
+			"integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
+			"dev": true
 		},
 		"sourcemap-codec": {
 			"version": "1.4.8",
@@ -7167,46 +6859,9 @@
 			}
 		},
 		"svelte": {
-			"version": "4.2.19",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.19.tgz",
-			"integrity": "sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==",
-			"requires": {
-				"@ampproject/remapping": "^2.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.15",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"@types/estree": "^1.0.1",
-				"acorn": "^8.9.0",
-				"aria-query": "^5.3.0",
-				"axobject-query": "^4.0.0",
-				"code-red": "^1.0.3",
-				"css-tree": "^2.3.1",
-				"estree-walker": "^3.0.3",
-				"is-reference": "^3.0.1",
-				"locate-character": "^3.0.0",
-				"magic-string": "^0.30.4",
-				"periscopic": "^3.1.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "8.12.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-					"integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg=="
-				},
-				"css-tree": {
-					"version": "2.3.1",
-					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-					"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-					"requires": {
-						"mdn-data": "2.0.30",
-						"source-map-js": "^1.0.1"
-					}
-				},
-				"mdn-data": {
-					"version": "2.0.30",
-					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-					"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
-				}
-			}
+			"version": "3.44.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.44.2.tgz",
+			"integrity": "sha512-jrZhZtmH3ZMweXg1Q15onb8QlWD+a5T5Oca4C1jYvSURp2oD35h4A5TV6t6MEa93K4LlX6BkafZPdQoFjw/ylA=="
 		},
 		"svelte-awesome": {
 			"version": "2.4.2",
@@ -7232,16 +6887,16 @@
 			}
 		},
 		"svelte-hmr": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.3.tgz",
-			"integrity": "sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==",
+			"version": "0.14.7",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.7.tgz",
+			"integrity": "sha512-pDrzgcWSoMaK6AJkBWkmgIsecW0GChxYZSZieIYfCP0v2oPyx2CYU/zm7TBIcjLVUPP714WxmViE9Thht4etog==",
 			"dev": true,
 			"requires": {}
 		},
 		"svelte-preprocess": {
-			"version": "4.10.7",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.10.7.tgz",
-			"integrity": "sha512-sNPBnqYD6FnmdBrUmBCaqS00RyCsCpj2BG58A1JBswNF7b0OKviwxqVrOL/CKyJrLSClrSeqQv5BXNg2RUbPOw==",
+			"version": "4.9.8",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.9.8.tgz",
+			"integrity": "sha512-EQS/oRZzMtYdAprppZxY3HcysKh11w54MgA63ybtL+TAZ4hVqYOnhw41JVJjWN9dhPnNjjLzvbZ2tMhTsla1Og==",
 			"dev": true,
 			"requires": {
 				"@types/pug": "^2.0.4",
@@ -7250,17 +6905,6 @@
 				"magic-string": "^0.25.7",
 				"sorcery": "^0.10.0",
 				"strip-indent": "^3.0.0"
-			},
-			"dependencies": {
-				"magic-string": {
-					"version": "0.25.9",
-					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-					"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-					"dev": true,
-					"requires": {
-						"sourcemap-codec": "^1.4.8"
-					}
-				}
 			}
 		},
 		"svgo": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"prettier": "^2.5.1",
 		"prettier-plugin-svelte": "^2.4.0",
 		"sass": "^1.39.0",
-		"svelte": "^4.2.19",
+		"svelte": "^3.42.4",
 		"svelte-check": "^2.2.5",
 		"svelte-preprocess": "^4.9.0",
 		"tailwindcss": "^2.2.9",


### PR DESCRIPTION
### Motivation

- Modernize the GitHub Pages deployment workflow by using newer actions and runner images and grant necessary `contents: write` permission for deployments.
- Simplify and rely on the `actions/setup-node@v4` built-in npm cache instead of a separate `actions/cache` step.
- Pin the project to a Svelte v3-compatible dependency set to maintain compatibility with the current toolchain and regenerate the `package-lock.json` accordingly.

### Description

- Updated `.github/workflows/build.yml` to set `permissions.contents: write`, use `runs-on: ubuntu-22.04`, upgrade `actions/checkout` to `v4`, and `actions/setup-node` to `v4` with `cache: npm`, removing the separate `actions/cache` step.
- Kept the deploy step using `peaceiris/actions-gh-pages@v3` and preserved the `npm ci` / `npm run build` steps and `publish_dir` configuration.
- Changed `package.json` to require `svelte` ^3.42.4 (downgrade from v4) and ensured `@sveltejs/kit` is set to `next` where applicable.
- Regenerated `package-lock.json` to reflect the updated dependency graph, which includes many adjusted package versions and the addition/removal of several transient dependencies (notably changes around Svelte & its plugin ecosystem such as `@sveltejs/vite-plugin-svelte`, `svelte-preprocess`, `svelte-hmr`, `magic-string`, `estree-walker`, and added helpers like `@rollup/pluginutils`, `require-relative`, and `@types/node`).

### Testing

- Ran `npm ci` locally to verify clean install of the updated lockfile and it completed successfully.
- Ran `npm run build` locally to verify the build pipeline with the adjusted dependencies and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b555140c483219e4c85a03c1e2e7b)